### PR TITLE
Subcommand description in top level help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Use `pip` or `easy_install` to install the library:
 
 	pip install arghandler
 
-or 
+or
 
-	easy_install arghandler 
+	easy_install arghandler
 
 You can find arghandler on pypi for relevant details should you need them.
 
@@ -92,18 +92,18 @@ several arguments:
 	ArgumentParser.set_logging_argument(*names,default_level=logging.ERROR,config_fxn=None)
 
 
-  * `*names` stands in for one or more arguments that specify the 
+  * `*names` stands in for one or more arguments that specify the
 	argument names that will be used. These follow the same rules as ones
 	passed into
 	[ArgumentParser.add_argument(...)](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument).
 	Moreover, they MUST be optional arguments (i.e., start with a '-'
 	character).
 
-  * `default_level` indicates the default level the logging 
+  * `default_level` indicates the default level the logging
 	framework will be set to should the level not be specified on the command
 	line.
 
-  * `config_fxn` allows the developer to write special logging 
+  * `config_fxn` allows the developer to write special logging
 	configuration code.  If not specified, the
 	[logging.basicConfig](https://docs.python.org/3/library/logging.html#logging.basicConfig)
 	function will be invoked with the appropriate logging level. The function
@@ -133,19 +133,19 @@ decorator on the function  you want to act as the subcommand.
 	@subcmd
 	def echo(parser,context,args):
 		print ' '.join(args)
-	
+
 	# here we associate the subcommand 'foobar' with function cmd_foobar
-	@subcmd('foobar')
+	@subcmd('foobar', help = 'Does foobar')
 	def cmd_foobar(parser,context,args):
 		print 'foobar'
 
 	handler = ArgumentHandler()
 	handler.run(['echo','hello','world']) # echo will be called and 'hello world' will be printed
 
-Notice that the subcommands always take three arguments. 
+Notice that the subcommands always take three arguments.
 
 `args` is the set of arguments that *follow* the subcommand on the command
-line. 
+line.
 
 `context` is an object that can make valuable global information available to
 subcommands.  By default, the context is the namespace object returned by the
@@ -181,7 +181,7 @@ command functions:
 
 	def echo(parser,context,args):
 		print ' '.join(args)
-	
+
 	def cmd_foobar(parser,context,args):
 		print 'foobar'
 
@@ -205,7 +205,7 @@ ensure that informative help messages are available for all your subcommands.
 		parser.add_argument('-q','--quote_char',required=True)
 		args = parser.parse_args(args)
 		print '%s%s%s' % (args.quote_char,' '.join(args),args.quote_char)
-	
+
 	@subcmd('foobar')
 	def cmd_foobar(parser,context,args):
 		print 'foobar'
@@ -216,5 +216,3 @@ ensure that informative help messages are available for all your subcommands.
 *Use logging.* Logging gives you much more control over what
 debugging/informational content is printed out by your program. And with
 `arghandler` it's easier than ever to configure from the command line!
-
-

--- a/arghandler/base.py
+++ b/arghandler/base.py
@@ -205,7 +205,7 @@ class ArgumentHandler(argparse.ArgumentParser):
 				subcommands_help_text += '\n'
 			self.add_argument('cmd',choices=self._subcommand_lookup.keys(), help = subcommands_help_text, metavar = 'subcommand')
 			self.add_argument('cargs',nargs=argparse.REMAINDER,
-								help='arguments for the subcommand')
+								help=argparse.SUPPRESS)
 
 		# parse arguments
 		args = argparse.ArgumentParser.parse_args(self,argv)


### PR DESCRIPTION
With this change **arghandler** can now show help text for subcommands in the top level help message it self.
Note that I have also suppressed the output of the dummy `cargs` argument.
