### PR TITLE
Show subcommand help as description

### DIFF
--- a/arghandler/base.py
+++ b/arghandler/base.py
@@ -289,7 +289,8 @@ class ArgumentHandler(argparse.ArgumentParser):
 
 		if self._use_subcommands:
 			# create the sub command argument parser
-			scmd_parser = argparse.ArgumentParser(prog='%s %s' % (self.prog,args.cmd))
+			scmd_parser = argparse.ArgumentParser(prog='%s %s' % (self.prog,args.cmd),
+                                                  description=self._subcommand_help[args.cmd])
 
 			# handle the subcommands
 			self._subcommand_lookup[args.cmd](scmd_parser,context,args.cargs)


### PR DESCRIPTION
The subcommands are currently not showing any description. I think they should default to the specified help text. I've tested this with `@subcmd('foo', help='halp me')`, resulting in:

```
usage: amo foo [-h] 

halp me

optional arguments:
  -h, --help  show this help message and exit
```

Would appreciate a release for this.